### PR TITLE
Exclude forced METRICS_SEPARATOR ending from prefix

### DIFF
--- a/src/main/java/com/appdynamics/extensions/memcached/config/Configuration.java
+++ b/src/main/java/com/appdynamics/extensions/memcached/config/Configuration.java
@@ -48,9 +48,9 @@ public class Configuration {
     }
 
     public void setMetricPrefix(String metricPrefix) {
-        if(!metricPrefix.endsWith(METRICS_SEPARATOR)){
+        /*if(!metricPrefix.endsWith(METRICS_SEPARATOR)){
             metricPrefix = metricPrefix + METRICS_SEPARATOR;
-        }
+        }*/
         this.metricPrefix = metricPrefix;
     }
 


### PR DESCRIPTION
This is to match configuration required for cluster monitoring.

[Memcached - Monitoring Extension](https://www.appdynamics.com/community/exchange/extension/memcached-monitoring-extension/)

Cluster level metrics -> Step 2. 
> To achieve this make the displayName to be empty string and remove the trailing "|" in the metricPrefix.